### PR TITLE
Add dates to all tools/toolkits and enable atom feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,8 @@ build_search_index = true
 
 theme = "anemone"
 
+generate_feeds = true
+
 taxonomies = [
   { name = "tags" },
   { name = "by" },

--- a/content/toolkits/black_kit/index.md
+++ b/content/toolkits/black_kit/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-02-10"
+updated = "2024-02-18"
 title = "Jarkman's Robot Fixing Toolkit"
 [taxonomies]
 by = ["jarkman"]

--- a/content/toolkits/drews_kit/index.md
+++ b/content/toolkits/drews_kit/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-03-12"
+updated = "2024-09-01"
 title = "Drew's Tiny Toolkit"
 [taxonomies]
 by = ["Drew"]

--- a/content/toolkits/hansers_main_kit/index.md
+++ b/content/toolkits/hansers_main_kit/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-09-05"
 title = "Hanser's Main Tiny Toolkit"
 [taxonomies]
 by = ["Hanser"]

--- a/content/toolkits/hansers_pc_kit/index.md
+++ b/content/toolkits/hansers_pc_kit/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-09-05"
 title = "Hanser's PC Toolkit"
 [taxonomies]
 by = ["Hanser"]

--- a/content/toolkits/hansers_power_kit/index.md
+++ b/content/toolkits/hansers_power_kit/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-09-09"
 title = "Hanser's Power Kit"
 [taxonomies]
 by = ["Hanser"]

--- a/content/toolkits/jarkmans-paper-club-kit.md
+++ b/content/toolkits/jarkmans-paper-club-kit.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-31"
+updated = "2024-02-18"
 title = "Jarkman's Paper Club Kit"
 +++
 

--- a/content/toolkits/jarkmans-soldering-toolkit.md
+++ b/content/toolkits/jarkmans-soldering-toolkit.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-03"
+updated = "2024-01-02"
 title = "Jarkman's Soldering Toolkit"
 +++
 

--- a/content/toolkits/jarkmans_flexure_kit.md
+++ b/content/toolkits/jarkmans_flexure_kit.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-31"
+updated = "2024-02-18"
 title = "Jarkman's Flexure Kit"
 +++
 

--- a/content/toolkits/kits_by_others/index.md
+++ b/content/toolkits/kits_by_others/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-09-02"
 title = "Tiny Tool Kits in the Wild"
 +++
 

--- a/content/toolkits/zyklop/index.md
+++ b/content/toolkits/zyklop/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-02-18"
 title = "Jarkman's Zyklop Kit"
 +++
 

--- a/content/tools/26-in-1/index.md
+++ b/content/tools/26-in-1/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-02-18"
 title = "Wiha 26-in-one screwdriver"
 [taxonomies]
 tags = ["things-that-turn"]

--- a/content/tools/4mm_set/index.md
+++ b/content/tools/4mm_set/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-02-18"
 title = "Tiny 4mm drive set"
 [taxonomies]
 tags = ["things-that-turn"]

--- a/content/tools/ANENG_A3008_Multimeter.md
+++ b/content/tools/ANENG_A3008_Multimeter.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-29"
+updated = "2024-01-30"
 title = "ANENG A3008 Multimeter"
 [taxonomies]
 by = ["Drew"]

--- a/content/tools/Atuman_R1_Ratchet_Wrench_Screwdriver_Kit.md
+++ b/content/tools/Atuman_R1_Ratchet_Wrench_Screwdriver_Kit.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-30"
+updated = "2024-06-03"
 title = "Atuman R1 Ratchet Wrench Screwdriver"
 [taxonomies]
 tags = ["things-that-screw"]

--- a/content/tools/Surgimax_tough_cut_scissors.md
+++ b/content/tools/Surgimax_tough_cut_scissors.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-01-02"
 title = "Surgimax 16cm tough cut scissors"
 [taxonomies]
 tags = ["things-that-cut"]

--- a/content/tools/alientek_dp100.md
+++ b/content/tools/alientek_dp100.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-03-02"
 title = "Alientek DP100 PSU"
 [taxonomies]
 tags = ["things-that-power"]

--- a/content/tools/cobolt.md
+++ b/content/tools/cobolt.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-03-02"
 title = "Knipex CoBolt tiny bolt cutters"
 [taxonomies]
 tags = ["things-that-cut"]

--- a/content/tools/cybertool-m/index.md
+++ b/content/tools/cybertool-m/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-31"
+updated = "2024-09-02"
 title = "Victorinox Cybertool M"
 [taxonomies]
 tags = ["things-that-cut", "things-that-screw", "things-that-hold", "things-that-pry"]

--- a/content/tools/facom-r180/index.md
+++ b/content/tools/facom-r180/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-03"
+updated = "2024-03-07"
 title = "Facom R.180PB 180° flexible head 1/4\" compact ratchet"
 [taxonomies]
 tags = ["things-that-turn"]

--- a/content/tools/ifixit_Mako_4mm_Screwdriver_Kit.md
+++ b/content/tools/ifixit_Mako_4mm_Screwdriver_Kit.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-01"
+updated = "2024-01-02"
 title = "iFixit Mako Compact Kit"
 [taxonomies]
 tags = ["things-that-screw"]

--- a/content/tools/jigsaw-handle/index.md
+++ b/content/tools/jigsaw-handle/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-06-30"
 title = "Jigsaw Handle"
 [taxonomies]
 tags = ["things-that-cut"]

--- a/content/tools/knipex-xs/index.md
+++ b/content/tools/knipex-xs/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-02-18"
 title = "Knipex XS"
 [taxonomies]
 tags = ["things-that-turn"]

--- a/content/tools/liquids/index.md
+++ b/content/tools/liquids/index.md
@@ -1,4 +1,5 @@
 +++
+date = "2024-09-05"
 title = "Liquids"
 [taxonomies]
 by = ["Hanser"]

--- a/content/tools/pinecil-soldering-iron/index.md
+++ b/content/tools/pinecil-soldering-iron/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-01"
+updated = "2024-09-02"
 title = "Pinecil soldering iron"
 [taxonomies]
 by = ["jarkman"]

--- a/content/tools/solder_sucker.md
+++ b/content/tools/solder_sucker.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-03"
+updated = "2024-09-02"
 title = "Engineer SS02 solder sucker"
 [taxonomies]
 tags = ["things-that-solder"]

--- a/content/tools/soldering-tins/index.md
+++ b/content/tools/soldering-tins/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-11-27"
+updated = "2024-09-02"
 title = "Soldering Tins"
 [taxonomies]
 tags = ["things-that-solder"]

--- a/content/tools/soldering_stand.md
+++ b/content/tools/soldering_stand.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-11-27"
+updated = "2024-09-02"
 title = "Soldering Iron Stand"
 [taxonomies]
 tags = ["things-that-solder"]

--- a/content/tools/third_hand.md
+++ b/content/tools/third_hand.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-03"
+updated = "2024-01-01"
 title = "Third Hand"
 [taxonomies]
 tags = ["things-that-hold"]

--- a/content/tools/tiny-knives/index.md
+++ b/content/tools/tiny-knives/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-12-31"
+updated = "2024-01-02"
 title = "Tiny knives"
 [taxonomies]
 tags = ["things-that-cut"]

--- a/content/tools/tiny-measures/index.md
+++ b/content/tools/tiny-measures/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-02-18"
+updated = "2024-06-22"
 title = "Tiny measuring and marking-out tools"
 [taxonomies]
 tags = ["things-that-measure"]

--- a/content/tools/tiny-pens-pencils/index.md
+++ b/content/tools/tiny-pens-pencils/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2023-11-25"
+updated = "2024-02-18"
 title = "Tiny pens & pencils"
 [taxonomies]
 by = ["jarkman"]

--- a/content/tools/tiny-prybar.md
+++ b/content/tools/tiny-prybar.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-02-18"
+updated = "2024-09-02"
 title = "Tiny prybar"
 [taxonomies]
 by = ["jarkman"]

--- a/content/tools/tiny-scissors/index.md
+++ b/content/tools/tiny-scissors/index.md
@@ -1,4 +1,6 @@
 +++
+date = "2024-01-02"
+updated = "2024-01-04"
 title = "Tiny scissors"
 [taxonomies]
 by = ["jarkman"]


### PR DESCRIPTION
I added dates to all tool and toolkit page front matter so that they show up in the Atom feed. The dates are based on dates added or modified in the git log. Zola considers any page with a date to be a feed item, and I confirmed that it generates a correct feed with auto discovery on the homepage. Fixes #7 